### PR TITLE
Fix linker borking when .iwram.data* (etc) sections are present

### DIFF
--- a/gba_cart.ld
+++ b/gba_cart.ld
@@ -160,8 +160,8 @@ SECTIONS
 	.iwram __iwram_start : AT (__iwram_lma)
 	{
 		__iwram_start__ = ABSOLUTE(.) ;
-		*(.iwram)
-		*iwram.*(.text*)
+		*(.iwram .iwram*)
+		*iwram.*(.text* .data*)
 		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
 		__iwram_end__ = ABSOLUTE(.) ;
 	} >iwram = 0xff
@@ -184,8 +184,7 @@ SECTIONS
 	.data ALIGN(4) : AT (__data_lma)
 	{
 		__data_start__ = ABSOLUTE(.);
-		*(.data)
-		*(.data.*)
+		*(.data*)
 		*(.gnu.linkonce.d*)
 		CONSTRUCTORS
 		. = ALIGN(4);
@@ -250,7 +249,7 @@ SECTIONS
 	__ewram_start = ORIGIN(ewram);
 	.ewram __ewram_start : AT (__ewram_lma)
 	{
-		*(.ewram)
+		*(.ewram*)
 		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
 		__ewram_end = ABSOLUTE(.);
 	}>ewram = 0xff
@@ -260,7 +259,7 @@ SECTIONS
 	.sbss ALIGN(4)(NOLOAD):
  	{
 		__sbss_start__ = ABSOLUTE(.);
- 		*(.sbss)
+ 		*(.sbss*)
  		. = ALIGN(4);
 		__sbss_end__  = ABSOLUTE(.);
 		__end__ = ABSOLUTE(.);


### PR DESCRIPTION
If those were present but not properly included by the script, the linker would get confused (I don't know how/why), and as a result, symbols would have overlapping LMAs, or sometimes `__data_end__` would even end up before `__data_start__`

This was *fun* to debug:

```
.data           0x0000000003001498        0x0 load address 0x0000000008010a14
                0x0000000003001498                __data_start__ = ABSOLUTE (.) <------------------------------- HELLO
 *(.data)
 *(.data.*)
 *(.gnu.linkonce.d*)
                0x0000000003001498 <-.            . = ALIGN (0x4)               <----------------------------------- WTF?
                0x0000000008010a14   |            __preinit_lma = (__data_lma + SIZEOF (.data))
                                     | ???
.igot.plt       0x0000000003000cd8 <-'    0x0 load address 0x00000000080111d4
 .igot.plt      0x0000000003000cd8        0x0 /opt/devkitpro/devkitARM/lib/gcc/arm-none-eabi/9.1.0/../../../../arm-none-eabi/lib/thumb/gba_crt0.o
```

(causing crt0 to hang)