### PR TITLE
GBA: Enable prefetch

### DIFF
--- a/gba_crt0.s
+++ b/gba_crt0.s
@@ -58,7 +58,11 @@ __slave_number:
 start_vector:
 @---------------------------------------------------------------------------------
 	mov	r0, #0x4000000			@ REG_BASE
-	str	r0, [r0, #0x208]
+	str	r0, [r0, #0x208]!		@ Clear IME. Disable IRQs
+
+	ldr	r1, [r0, #0x204]
+	orr	r1, #0x4000			@ Enable prefetch
+	str	r1, [r0, #0x204]		@ Write WAITCNT register
 
 	mov	r0, #0x12			@ Switch to IRQ Mode
 	msr	cpsr, r0


### PR DESCRIPTION
So I was doing some performance testing on an emulator and realized that the reason why my code was so slow is that WAITCNT was set to the default value of 0. That means: The highest waitstates for everything and no ROM prefetch enabled.

I'm opening this PR also to discuss what should be done about it. Enabling the prefetch bit seems harmless enough, but setting the waitstates is a bit trickier. For example, the SuperCard SD needs a WS0 setting of 4.1, while most games use 3.1.

The safest option is to use the defaults, except for WS0, so that SCSD works.

This is only a problem for emulators and in case someone creates a cartridge with the ROM. When using flashcarts, I'm sure that the boot menu sets WAITCNT to some value, so it's unlikely it would make any difference to change that value. In any case, the current situation isn't great.