### PR TITLE
Fix gba_cart.ld support for overlays

### DIFF
--- a/gba_cart.ld
+++ b/gba_cart.ld
@@ -12,15 +12,15 @@
 /*         support added to allow labels end, _end, */
 /*         & __end__ to point to end of iwram or    */
 /*         the end of ewram.                        */
-/*	Additions by WinterMute				*/
-/* v1.4 -	.sbss section added for unitialised	*/
-/*		    data in ewram 			*/
-/* v1.5 -	padding section added to stop EZF 	*/
-/*		    stripping important data		*/
+/*	Additions by WinterMute				            */
+/* v1.4 -	.sbss section added for unitialised	    */
+/*		    data in ewram 			                */
+/* v1.5 -	padding section added to stop EZF 	    */
+/*		    stripping important data		        */
 
 /* This file is released into the public domain		*/
 /* for commercial or non-commercial use with no		*/
-/* restrictions placed upon it.				*/
+/* restrictions placed upon it.				        */
 
 /* NOTE!!!: This linker script defines the RAM &  */
 /*   ROM start addresses. In order for it to work */
@@ -28,12 +28,12 @@
 /*   options from your makefile if they are       */
 /*   present.                                     */
 
-/* You can use the following to view section      */
-/* addresses in your .elf file:                   */
-/*   objdump -h file.elf                          */
-/* Please note that empty sections may incorrectly*/
-/* list the lma address as the vma address for    */
-/* some versions of objdump.                      */
+/* You can use the following to view section       */
+/* addresses in your .elf file:                    */
+/*   objdump -h file.elf                           */
+/* Please note that empty sections may incorrectly */
+/* list the lma address as the vma address for     */
+/* some versions of objdump.                       */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -160,8 +160,8 @@ SECTIONS
 	.iwram __iwram_start : AT (__iwram_lma)
 	{
 		__iwram_start__ = ABSOLUTE(.) ;
-		*(.iwram .iwram*)
-		*iwram.*(.text* .data*)
+		*(.iwram)
+		*iwram.*(.text*)
 		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
 		__iwram_end__ = ABSOLUTE(.) ;
 	} >iwram = 0xff
@@ -184,7 +184,8 @@ SECTIONS
 	.data ALIGN(4) : AT (__data_lma)
 	{
 		__data_start__ = ABSOLUTE(.);
-		*(.data*)
+		*(.data)
+		*(.data.*)
 		*(.gnu.linkonce.d*)
 		CONSTRUCTORS
 		. = ALIGN(4);
@@ -251,7 +252,9 @@ SECTIONS
 	__ewram_start = ORIGIN(ewram);
 	.ewram __ewram_start : AT (__ewram_lma)
 	{
-		*(.ewram*)
+		*(.ewram)
+		*(.ewram.*)
+		*ewram.*(.text.*)
 		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
 		__ewram_end = ABSOLUTE(.);
 	}>ewram = 0xff
@@ -261,7 +264,8 @@ SECTIONS
 	.sbss ALIGN(4)(NOLOAD):
  	{
 		__sbss_start__ = ABSOLUTE(.);
- 		*(.sbss*)
+ 		*(.sbss)
+		*(.sbss.*)
  		. = ALIGN(4);
 		__sbss_end__  = ABSOLUTE(.);
 		__end__ = ABSOLUTE(.);

--- a/gba_cart.ld
+++ b/gba_cart.ld
@@ -242,7 +242,9 @@ SECTIONS
 	}>iwram = 0xff
 
 	__iwram_overlay_end = . ;
-	__ewram_lma = __iwram_overlay_lma + (__iwram_overlay_end - __iwram_overlay_start) ;
+	__ewram_lma = __iwram_overlay_lma + SIZEOF(.iwram0) + SIZEOF(.iwram1) + SIZEOF(.iwram2) +
+		SIZEOF(.iwram3) + SIZEOF(.iwram4) + SIZEOF(.iwram5) + SIZEOF(.iwram6) +
+		SIZEOF(.iwram7) + SIZEOF(.iwram8) + SIZEOF(.iwram9) ;
 
 	__iheap_start = . ;
 

--- a/gba_cart.ld
+++ b/gba_cart.ld
@@ -12,15 +12,15 @@
 /*         support added to allow labels end, _end, */
 /*         & __end__ to point to end of iwram or    */
 /*         the end of ewram.                        */
-/*	Additions by WinterMute				            */
-/* v1.4 -	.sbss section added for unitialised	    */
-/*		    data in ewram 			                */
-/* v1.5 -	padding section added to stop EZF 	    */
-/*		    stripping important data		        */
+/*	Additions by WinterMute				*/
+/* v1.4 -	.sbss section added for unitialised	*/
+/*		    data in ewram 			*/
+/* v1.5 -	padding section added to stop EZF 	*/
+/*		    stripping important data		*/
 
 /* This file is released into the public domain		*/
 /* for commercial or non-commercial use with no		*/
-/* restrictions placed upon it.				        */
+/* restrictions placed upon it.				*/
 
 /* NOTE!!!: This linker script defines the RAM &  */
 /*   ROM start addresses. In order for it to work */
@@ -28,12 +28,12 @@
 /*   options from your makefile if they are       */
 /*   present.                                     */
 
-/* You can use the following to view section       */
-/* addresses in your .elf file:                    */
-/*   objdump -h file.elf                           */
-/* Please note that empty sections may incorrectly */
-/* list the lma address as the vma address for     */
-/* some versions of objdump.                       */
+/* You can use the following to view section      */
+/* addresses in your .elf file:                   */
+/*   objdump -h file.elf                          */
+/* Please note that empty sections may incorrectly*/
+/* list the lma address as the vma address for    */
+/* some versions of objdump.                      */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -161,7 +161,7 @@ SECTIONS
 	{
 		__iwram_start__ = ABSOLUTE(.) ;
 		*(.iwram)
-		*iwram.*(.text*)
+		*iwram.*(.text* .data*)
 		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
 		__iwram_end__ = ABSOLUTE(.) ;
 	} >iwram = 0xff
@@ -184,8 +184,7 @@ SECTIONS
 	.data ALIGN(4) : AT (__data_lma)
 	{
 		__data_start__ = ABSOLUTE(.);
-		*(.data)
-		*(.data.*)
+		*(.data*)
 		*(.gnu.linkonce.d*)
 		CONSTRUCTORS
 		. = ALIGN(4);
@@ -252,9 +251,7 @@ SECTIONS
 	__ewram_start = ORIGIN(ewram);
 	.ewram __ewram_start : AT (__ewram_lma)
 	{
-		*(.ewram)
-		*(.ewram.*)
-		*ewram.*(.text.*)
+		*(.ewram*)
 		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
 		__ewram_end = ABSOLUTE(.);
 	}>ewram = 0xff
@@ -264,8 +261,7 @@ SECTIONS
 	.sbss ALIGN(4)(NOLOAD):
  	{
 		__sbss_start__ = ABSOLUTE(.);
- 		*(.sbss)
-		*(.sbss.*)
+ 		*(.sbss*)
  		. = ALIGN(4);
 		__sbss_end__  = ABSOLUTE(.);
 		__end__ = ABSOLUTE(.);


### PR DESCRIPTION
The current linker script uses `__iwram_overlay_end - __iwram_overlay_start` as an offset for `__ewram_lma`, which uses only the maximum size of an IWRAM overlay and is wrong even for only 2 overlays (section `.ewram`'s LMA will overlap with `.iwram1`'s LMA). This fix makes it correctly consider the total size of all overlays when computing the LMA for section `.ewram`.