### PR TITLE
Store alignment of .tdata as read-only variable

### DIFF
--- a/3dsx.ld
+++ b/3dsx.ld
@@ -56,6 +56,9 @@ SECTIONS
 		*(.gnu.linkonce.r*)
 		SORT(CONSTRUCTORS)
 		. = ALIGN(4);
+		__tdata_align = .;
+		LONG (MAX(8, ALIGNOF(.tdata)));
+		. = ALIGN(4);
 	} : rodata
 
 	.ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } : rodata
@@ -76,7 +79,7 @@ SECTIONS
 		. = ALIGN(4);
 	} : data
 
-	.tdata ALIGN(4) :
+	.tdata ALIGN(MAX(8, ALIGNOF(.tdata))) :
 	{
 		__tdata_lma = .;
 		*(.tdata)
@@ -142,9 +145,9 @@ SECTIONS
 		*(.bss.*)
 		*(.gnu.linkonce.b*)
 		*(COMMON)
-		. = ALIGN(4);
 
 		/* Reserve space for the TLS segment of the main thread */
+		. = ALIGN(MAX(8, ALIGNOF(.tdata)));
 		__tls_start = .;
 		. += + SIZEOF(.tdata) + SIZEOF(.tbss);
 		__tls_end = .;

--- a/3dsx.ld
+++ b/3dsx.ld
@@ -57,7 +57,7 @@ SECTIONS
 		SORT(CONSTRUCTORS)
 		. = ALIGN(4);
 		__tdata_align = .;
-		LONG (MAX(8, ALIGNOF(.tdata)));
+		LONG (ALIGNOF(.tdata));
 		. = ALIGN(4);
 	} : rodata
 
@@ -79,7 +79,7 @@ SECTIONS
 		. = ALIGN(4);
 	} : data
 
-	.tdata ALIGN(MAX(8, ALIGNOF(.tdata))) :
+	.tdata ALIGN(4) :
 	{
 		__tdata_lma = .;
 		*(.tdata)
@@ -146,10 +146,15 @@ SECTIONS
 		*(.gnu.linkonce.b*)
 		*(COMMON)
 
-		/* Reserve space for the TLS segment of the main thread */
-		. = ALIGN(MAX(8, ALIGNOF(.tdata)));
+		/* Reserve space for the TLS segment of the main thread.
+		   We need (__tls_start - 8) to be aligned the same as .tdata, to account for
+		   the 8-byte ARM TLS header. Since the header is not actually used for
+		   ARM_TLS_LE32 relocation, we just fake it by subtracting 8 from the data
+		   offset.
+		 */
+		. = 8 + ABSOLUTE(ALIGN(ABSOLUTE(. - 8), MAX(4, ALIGNOF(.tdata))));
 		__tls_start = .;
-		. += + SIZEOF(.tdata) + SIZEOF(.tbss);
+		. += SIZEOF(.tdata) + SIZEOF(.tbss);
 		__tls_end = .;
 	} : data
 	__bss_end__ = .;


### PR DESCRIPTION
Also ensure __tls_start alignment matches that of .tdata, and use a
minimum align of 8 for the 8-byte ARM TLS header.

This is part of the solution to https://github.com/devkitPro/libctru/issues/497 and an accompanying PR will be opened there.