### PR TITLE
Fix TLS section alignment for ".tdata" size edge-cases

### DIFF
--- a/3dsx.ld
+++ b/3dsx.ld
@@ -159,7 +159,7 @@ SECTIONS
 		   ARM_TLS_LE32 relocation, we just fake it by subtracting 8 from the data
 		   offset.
 		 */
-		. = 8 + ABSOLUTE(ALIGN(ABSOLUTE(. - 8), ALIGNOF(.tdata)));
+		. = 8 + ABSOLUTE(ALIGN(ABSOLUTE(. - 8), MAX(ALIGNOF(.tdata), ALIGNOF(.tbss))));
 		__tls_start = .;
 		. += SIZEOF(.tdata);
 


### PR DESCRIPTION
This is a small modification of the changes brought in #7.

As dug up in https://github.com/rust3ds/ctru-rs/issues/124, it seems that thread-local data is misaligned if the `.tdata` section is either empty or wrongly sized, causing the `.tbss` data to be placed without proper alignment (which for most cases should be 8 bytes). With this change we ensure the linker takes into account the needs of both `.tdata` and `.tbss`, so that a more dynamic alignment can be established.

Unlike previous reports, we were unable to find a reproducible test case for C code written with the `devkitARM` toolchain, since it seems that the latest changes in the `rustc` compiler brought these issues to light (due to a change in how the compiler specifies the link order for TLS variables, and not for an actual internal bug).

Regardless, for all intents and purposes, this change corrects previous oversights.

Suggested by @Jhynjhiruu.
CC @ian-h-chamberlain @patataofcourse