### PR TITLE
Fix Makefile: ensure directory creation before object compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,16 @@ armv6k/fpu:
 thumb:
 	@mkdir -p $@
 
-armv6k/fpu/3dsx_crt0.o: 3dsx_crt0.s
+armv6k/fpu/3dsx_crt0.o: 3dsx_crt0.s | armv6k/fpu
 	$(CC) -march=armv6k -mfloat-abi=hard -c $< -o $@
 
-thumb/%_vram_crt0.o: %_crt0.s
+thumb/%_vram_crt0.o: %_crt0.s | thumb
 	$(CC)  -x assembler-with-cpp -DVRAM -mthumb -c $< -o$@
 
 %_vram_crt0.o: %_crt0.s
 	$(CC)  -x assembler-with-cpp -DVRAM -marm -c $< -o$@
 
-thumb/%_crt0.o: %_crt0.s
+thumb/%_crt0.o: %_crt0.s | thumb
 	$(CC)  -x assembler-with-cpp -mthumb -c $< -o$@
 
 %_crt0.o: %_crt0.s


### PR DESCRIPTION
Address a race condition in the Makefile where object files were being compiled before their target directories were created, leading to build failures during parallel execution. This fix explicitly defines directory dependencies for object files, ensuring that necessary directories are created prior to compilation, thereby supporting parallel builds without errors.

```sh
$ make clean && make -j12
rm -fr thumb armv6k *.o
arm-none-eabi-gcc  -x assembler-with-cpp -DVRAM -marm -c ds_arm7_crt0.s -ods_arm7_vram_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -DVRAM -mthumb -c ds_arm7_crt0.s -othumb/ds_arm7_vram_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -marm -c ds_arm7_crt0.s -ods_arm7_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -mthumb -c ds_arm7_crt0.s -othumb/ds_arm7_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -marm -c ds_arm9_crt0.s -ods_arm9_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -mthumb -c ds_arm9_crt0.s -othumb/ds_arm9_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -marm -c gba_crt0.s -ogba_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -mthumb -c gba_crt0.s -othumb/gba_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -marm -c er_crt0.s -oer_crt0.o
arm-none-eabi-gcc  -x assembler-with-cpp -mthumb -c er_crt0.s -othumb/er_crt0.o
Assembler messages:
Fatal error: can't create thumb/ds_arm7_crt0.o: No such file or directory
make: *** [Makefile:38: thumb/ds_arm7_crt0.o] Error 1
make: *** Waiting for unfinished jobs....
```